### PR TITLE
Permissions Checked

### DIFF
--- a/lib/rk_backend/repo/auth.ex
+++ b/lib/rk_backend/repo/auth.ex
@@ -69,6 +69,8 @@ defmodule RkBackend.Repo.Auth do
   @doc """
   Stores an user.
 
+  Users will have the role 'USER' by default.
+
   ## Examples
 
       iex> store_user(%{field: value})
@@ -79,6 +81,9 @@ defmodule RkBackend.Repo.Auth do
 
   """
   def store_user(attrs \\ %{}) do
+    users_role = Repo.get_by!(Role, type: "USER")
+    attrs = Map.put(attrs, :role_id, users_role.id)
+
     %User{}
     |> User.changeset(attrs)
     |> Repo.insert()
@@ -138,14 +143,15 @@ defmodule RkBackend.Repo.Auth do
       {:error, :string}
 
   """
-  def update_user(%{user_update_details: user_update_details}, _info) do
+  def update_user(user_update, _info) do
     try do
-      with user = %User{} <- Repo.get(User, user_update_details.id),
-           {:ok, user} <- update_user(user, user_update_details) do
+      with user_update = %{} <- get_user_update(user_update),
+           user = %User{} <- Repo.get(User, user_update.id),
+           {:ok, user} <- update_user(user, user_update) do
         {:ok, user}
       else
         nil ->
-          {:error, "ID: #{user_update_details.id} not found"}
+          {:error, "ID: #{user_update.id} not found"}
 
         {:error, changeset} ->
           errors = RkBackend.Utils.changeset_errors_to_string(changeset)
@@ -157,6 +163,14 @@ defmodule RkBackend.Repo.Auth do
         Logger.error("Invalid argument given")
         {:error, "Invalid argument given"}
     end
+  end
+
+  defp get_user_update(%{user_update_details: user_update}) do
+    user_update
+  end
+
+  defp get_user_update(%{user_update_role: user_update}) do
+    user_update
   end
 
   @doc """

--- a/lib/rk_backend/repo/auth.ex
+++ b/lib/rk_backend/repo/auth.ex
@@ -151,6 +151,7 @@ defmodule RkBackend.Repo.Auth do
         {:ok, user}
       else
         nil ->
+          user_update = get_user_update(user_update)
           {:error, "ID: #{user_update.id} not found"}
 
         {:error, changeset} ->

--- a/lib/rk_backend_web/schema.ex
+++ b/lib/rk_backend_web/schema.ex
@@ -12,7 +12,6 @@ defmodule RkBackendWeb.Schema do
     field :full_name, non_null(:string)
     field :password, non_null(:string)
     field :password_confirmation, non_null(:string)
-    field :role_id, non_null(:integer)
   end
 
   input_object :user_update_details do
@@ -21,7 +20,11 @@ defmodule RkBackendWeb.Schema do
     field :full_name, :string
     field :password, :string
     field :password_confirmation, :string
-    field :role_id, :integer
+  end
+
+  input_object :user_update_role do
+    field :id, non_null(:integer)
+    field :role_id, non_null(:integer)
   end
 
   query do
@@ -85,9 +88,18 @@ defmodule RkBackendWeb.Schema do
       middleware(RkBackend.Middlewares.HandleErrors)
     end
 
+    @desc "Update user's role"
+    field :update_users_role, :user do
+      arg(:user_update_role, non_null(:user_update_role))
+      middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
+      resolve(&RkBackend.Repo.Auth.update_user/2)
+      middleware(RkBackend.Middlewares.HandleErrors)
+    end
+
     @desc "Create a role"
     field :create_role, :role do
       arg(:type, non_null(:string))
+      middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&RkBackend.Repo.Auth.store_role/3)
       middleware(RkBackend.Middlewares.HandleErrors)
     end

--- a/test/rk_backend/logic/auth/sign_in_test.exs
+++ b/test/rk_backend/logic/auth/sign_in_test.exs
@@ -5,7 +5,7 @@ defmodule RkBackend.Logic.Auth.SignInTest do
   alias RkBackend.Repo.Auth
 
   describe "SignIn" do
-    @valid_attrs_role %{type: "some type"}
+    @valid_attrs_role %{type: "USER"}
 
     @valid_attrs_user %{
       email: "some email",

--- a/test/rk_backend/repo/auth/auth_test.exs
+++ b/test/rk_backend/repo/auth/auth_test.exs
@@ -60,6 +60,8 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "store_user/1 with invalid data returns error changeset" do
+      role_fixture()
+
       assert {:error, %Ecto.Changeset{}} = Auth.store_user(@invalid_attrs)
     end
 
@@ -77,7 +79,9 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "store_user/3 unsuccessful" do
-      args = %{user_details: @valid_attrs}
+      role_fixture()
+
+      args = %{user_details: @invalid_attrs}
       assert {:error, changeset} = Auth.store_user(nil, args, nil)
     end
 
@@ -151,7 +155,7 @@ defmodule RkBackend.Repo.AuthTest do
   end
 
   describe "roles" do
-    @valid_attrs %{type: "some type"}
+    @valid_attrs %{type: "USER"}
     @update_attrs %{type: "some updated type"}
     @invalid_attrs %{type: nil}
 
@@ -176,7 +180,7 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "store_role/1 with valid data creates a role" do
       assert {:ok, %Role{} = role} = Auth.store_role(@valid_attrs)
-      assert role.type == "some type"
+      assert role.type == "USER"
     end
 
     test "store_role/1 with invalid data returns error changeset" do
@@ -185,7 +189,7 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "store_role/3 successful" do
       assert {:ok, %Role{} = role} = Auth.store_role(nil, @valid_attrs, nil)
-      assert role.type == "some type"
+      assert role.type == "USER"
     end
 
     test "store_role/3 unsuccessful" do


### PR DESCRIPTION
- The calls for updating and creating users has been changed. Now users can only create users with the USER role, which is now the default, and will not be able to update the tole.

- A new call to update roles has been created and only ADMIN will be able to access it.

closes #4 