### PR TITLE
Rewrite User Update

### DIFF
--- a/lib/rk_backend/repo/auth.ex
+++ b/lib/rk_backend/repo/auth.ex
@@ -51,7 +51,7 @@ defmodule RkBackend.Repo.Auth do
   end
 
   @doc """
-  Updates a user.
+  Updates an user.
 
   ## Examples
 
@@ -62,10 +62,19 @@ defmodule RkBackend.Repo.Auth do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_user(%User{} = user, args) do
-    user
-    |> User.update_changeset(args)
-    |> Repo.update()
+  def update_user(args) do
+    {id, args} = Map.pop(args, :id)
+
+    case Repo.get(User, id) do
+      %User{} = user ->
+        user
+        |> Repo.dynamically_preload(args)
+        |> User.update_changeset(args)
+        |> Repo.update()
+
+      nil ->
+        {:error, "User not found"}
+    end
   end
 
   @doc """
@@ -149,10 +158,19 @@ defmodule RkBackend.Repo.Auth do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_role(%Role{} = role, args) do
-    role
-    |> Role.changeset(args)
-    |> Repo.update()
+  def update_role(args) do
+    {id, args} = Map.pop(args, :id)
+
+    case Repo.get(Role, id) do
+      %Role{} = role ->
+        role
+        |> Repo.dynamically_preload(args)
+        |> Role.update_changeset(args)
+        |> Repo.update()
+
+      nil ->
+        {:error, "Role not found"}
+    end
   end
 
   @doc """

--- a/lib/rk_backend/repo/auth/role.ex
+++ b/lib/rk_backend/repo/auth/role.ex
@@ -23,4 +23,13 @@ defmodule RkBackend.Repo.Auth.Role do
     |> validate_required(@required)
     |> unique_constraint(:type)
   end
+
+  @update_required []
+  @update_optional [:type]
+  @doc false
+  def update_changeset(role, args) do
+    role
+    |> cast(args, @update_required ++ @update_optional)
+    |> unique_constraint(:type)
+  end
 end

--- a/lib/rk_backend/repo/auth/user.ex
+++ b/lib/rk_backend/repo/auth/user.ex
@@ -33,10 +33,12 @@ defmodule RkBackend.Repo.Auth.User do
     |> put_password_hash
   end
 
+  @update_required []
+  @update_optional [:email, :full_name, :password, :password_confirmation, :role_id]
   @doc false
   def update_changeset(user, args) do
     user
-    |> cast(args, @required ++ @optional)
+    |> cast(args, @update_required ++ @update_optional)
     |> unique_constraint(:email)
     |> validate_confirmation(:password, message: "does not match password")
     |> foreign_key_constraint(:role_id)

--- a/lib/rk_backend_web/queries/auth_queries.ex
+++ b/lib/rk_backend_web/queries/auth_queries.ex
@@ -68,7 +68,7 @@ defmodule RkBackendWeb.Schema.Queries.AuthQueries do
       middleware(RkBackend.Middlewares.HandleErrors)
     end
 
-    @desc "Update user's role"
+    @desc "Update user ADMIN"
     field :update_users_role, :user do
       arg(:user_update_role, non_null(:user_update_role))
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])

--- a/lib/rk_backend_web/resolvers/auth_resolvers.ex
+++ b/lib/rk_backend_web/resolvers/auth_resolvers.ex
@@ -59,34 +59,25 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
     end
   end
 
-  def update_user(user_update, _info) do
-    try do
-      with user_update = %{} <- get_user_update(user_update),
-           user = %User{} <- Repo.get(User, user_update.id),
-           {:ok, user} <- Auth.update_user(user, user_update) do
-        {:ok, user}
-      else
-        nil ->
-          user_update = get_user_update(user_update)
-          {:error, "ID: #{user_update.id} not found"}
+  def update_user(args, _info) do
+    update_details = get_user_update_details(args)
 
-        {:error, errors} ->
-          errors = Utils.errors_to_string(errors)
-          Logger.error(errors)
-          {:error, errors}
-      end
-    rescue
-      ArgumentError ->
-        Logger.error("Invalid argument given")
-        {:error, "Invalid argument given"}
+    case Auth.update_user(update_details) do
+      {:ok, user} ->
+        {:ok, user}
+
+      {:error, errors} ->
+        errors = Utils.errors_to_string(errors)
+        Logger.error(errors)
+        {:error, errors}
     end
   end
 
-  defp get_user_update(%{user_update_details: user_update}) do
+  defp get_user_update_details(%{user_update_details: user_update}) do
     user_update
   end
 
-  defp get_user_update(%{user_update_role: user_update}) do
+  defp get_user_update_details(%{user_update_role: user_update}) do
     user_update
   end
 

--- a/test/rk_backend/repo/auth/auth_test.exs
+++ b/test/rk_backend/repo/auth/auth_test.exs
@@ -86,14 +86,24 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "update_user/2 with valid data updates the user" do
       user = user_fixture()
-      assert {:ok, %User{} = user} = Auth.update_user(user, @update_args)
+
+      update_args =
+        @update_args
+        |> Map.put(:id, user.id)
+
+      assert {:ok, %User{} = user} = Auth.update_user(update_args)
       assert user.email == "some updated email"
       assert user.full_name == "some updated full_name"
     end
 
     test "update_user/2 with invalid data returns error changeset" do
       user = user_fixture()
-      assert {:error, %Ecto.Changeset{}} = Auth.update_user(user, @invalid_args)
+
+      invalid_args =
+        @invalid_args
+        |> Map.put(:id, user.id)
+
+      assert {:error, %Ecto.Changeset{}} = Auth.update_user(invalid_args)
     end
 
     test "update_user/2 successful" do
@@ -103,7 +113,7 @@ defmodule RkBackend.Repo.AuthTest do
         @update_args
         |> Map.put(:id, user.id)
 
-      assert {:ok, user = %User{}} = Auth.update_user(user, update_args)
+      assert {:ok, user = %User{}} = Auth.update_user(update_args)
       assert user.password == "password2"
     end
 
@@ -114,7 +124,7 @@ defmodule RkBackend.Repo.AuthTest do
         @invalid_args
         |> Map.put(:id, user.id)
 
-      assert {:error, reason} = Auth.update_user(user, update_args)
+      assert {:error, reason} = Auth.update_user(update_args)
       assert reason = "password_confirmation: does not match password\n"
     end
 
@@ -173,14 +183,23 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "update_role/2 with valid data updates the role" do
       role = role_fixture()
-      assert {:ok, %Role{} = role} = Auth.update_role(role, @update_args)
+
+      update_args =
+        @update_args
+        |> Map.put(:id, role.id)
+
+      assert {:ok, %Role{} = role} = Auth.update_role(update_args)
       assert role.type == "some updated type"
     end
 
     test "update_role/2 with invalid data returns error changeset" do
       role = role_fixture()
-      assert {:error, %Ecto.Changeset{}} = Auth.update_role(role, @invalid_args)
-      assert role == Auth.get_role!(role.id)
+
+      invalid_args =
+        @invalid_args
+        |> Map.put(:id, role.id)
+
+      assert_raise Postgrex.Error, fn -> Auth.update_role(invalid_args) end
     end
 
     test "delete_role/1 deletes the role" do


### PR DESCRIPTION
Methods user_update and role_update rewritten to be easily understood.
All references to update_changeset have been removed.

Closes #26