### PR TITLE
Dataloader

### DIFF
--- a/lib/rk_backend.ex
+++ b/lib/rk_backend.ex
@@ -6,4 +6,13 @@ defmodule RkBackend do
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
   """
+
+  def rk_data() do
+    Dataloader.Ecto.new(RkBackend.Repo, query: &query/2)
+  end
+
+  def query(queryable, _params) do
+    queryable
+  end
+
 end

--- a/lib/rk_backend_web/context.ex
+++ b/lib/rk_backend_web/context.ex
@@ -1,0 +1,9 @@
+defmodule RkBackendWeb.Context do
+
+  def dataloader() do
+    Dataloader.new
+    |> Dataloader.add_source(RkBackend, RkBackend.rk_data())
+  end
+
+
+end

--- a/lib/rk_backend_web/schema.ex
+++ b/lib/rk_backend_web/schema.ex
@@ -1,6 +1,18 @@
 defmodule RkBackendWeb.Schema do
   use Absinthe.Schema
 
+  def context(ctx) do
+    loader =
+      Dataloader.new
+      |> Dataloader.add_source(RkBackend, RkBackend.rk_data())
+
+    Map.put(ctx, :loader, loader)
+  end
+
+  def plugins do
+    [Absinthe.Middleware.Dataloader] ++ Absinthe.Plugin.defaults()
+  end
+
   @moduledoc """
   Endpoints supported by GraphQL in this application
   """

--- a/lib/rk_backend_web/types/auth_types.ex
+++ b/lib/rk_backend_web/types/auth_types.ex
@@ -1,6 +1,7 @@
 defmodule RkBackendWeb.Schema.Types.AuthTypes do
   use Absinthe.Schema.Notation
-  use Absinthe.Ecto, repo: RkBackend.Repo
+
+  import Absinthe.Resolution.Helpers, only: [dataloader: 1]
 
   @moduledoc """
   Auth Types supported by GraphQL in this application
@@ -33,7 +34,7 @@ defmodule RkBackendWeb.Schema.Types.AuthTypes do
     field :id, :id
     field :email, :string
     field :full_name, :string
-    field :role, :role, resolve: assoc(:role)
+    field :role, :role, resolve: dataloader(RkBackend)
 
     interface(:user_entity)
   end
@@ -43,7 +44,7 @@ defmodule RkBackendWeb.Schema.Types.AuthTypes do
     field :id, :id
     field :email, :string
     field :full_name, :string
-    field :role, :role, resolve: assoc(:role)
+    field :role, :role, resolve: dataloader(RkBackend)
     field :token, :string
 
     interface(:user_entity)

--- a/lib/rk_backend_web/types/complaint_types.ex
+++ b/lib/rk_backend_web/types/complaint_types.ex
@@ -1,6 +1,7 @@
 defmodule RkBackendWeb.Schema.Types.ComplaintTypes do
   use Absinthe.Schema.Notation
-  use Absinthe.Ecto, repo: RkBackend.Repo
+
+  import Absinthe.Resolution.Helpers, only: [dataloader: 1]
 
   @moduledoc """
   Complaint Types supported by GraphQL in this application
@@ -11,10 +12,10 @@ defmodule RkBackendWeb.Schema.Types.ComplaintTypes do
     field :title, :string
     field :content, :string
     field :inserted_at, :datetime
-    field :user, :user, resolve: assoc(:user)
-    field :topic, :topic, resolve: assoc(:topic)
-    field :messages, list_of(:message), resolve: assoc(:messages)
-    field :images, list_of(:image), resolve: assoc(:images)
+    field :user, :user, resolve: dataloader(RkBackend)
+    field :topic, :topic, resolve: dataloader(RkBackend)
+    field :messages, list_of(:message), resolve: dataloader(RkBackend)
+    field :images, list_of(:image), resolve: dataloader(RkBackend)
   end
 
   object :paginated_reklama do
@@ -40,8 +41,8 @@ defmodule RkBackendWeb.Schema.Types.ComplaintTypes do
     field :id, :id
     field :content, :string
     field :inserted_at, :datetime
-    field :user, :user, resolve: assoc(:user)
-    field :reklama, :reklama, resolve: assoc(:reklama)
+    field :user, :user, resolve: dataloader(RkBackend)
+    field :reklama, :reklama, resolve: dataloader(RkBackend)
   end
 
   input_object :reklama_details do

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule RkBackend.MixProject do
       {:gettext, "~> 0.17.0"},
       {:plug_cowboy, "~> 2.1.0"},
       {:absinthe, "~> 1.4.16"},
-      {:absinthe_ecto, "~> 0.1.3"},
+      {:dataloader, "~> 1.0.0"},
       {:absinthe_plug, "~> 1.4.7"},
       {:jason, "~> 1.1.2"},
       {:logger_file_backend, "~> 0.0.11"},

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,7 @@
   "cowboy": {:hex, :cowboy, "2.7.0", "91ed100138a764355f43316b1d23d7ff6bdb0de4ea618cb5d8677c93a7a2f115", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.8.0", "fd0ff1787db84ac415b8211573e9a30a3ebe71b5cbff7f720089972b2319c8a4", [:rebar3], [], "hexpm"},
   "credo": {:hex, :credo, "1.1.5", "caec7a3cadd2e58609d7ee25b3931b129e739e070539ad1a0cd7efeeb47014f4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "dataloader": {:hex, :dataloader, "1.0.7", "58351b335673cf40601429bfed6c11fece6ce7ad169b2ac0f0fe83e716587391", [:mix], [{:ecto, ">= 0.0.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "2.1.1", "a51e8a2ee54ef2ae6ec41a668c85787ed40cb8944928c191280fe34c15b76ae5", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "3.2.3", "51274df79862845b388733fddcf6f107d0c8c86e27abe7131fa98f8d30761bda", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},


### PR DESCRIPTION
Absinthe.Ecto was removed because it is deprecated.

Library Absinthe.Ecto was substituted with Dataloader. Configuration was added in order to make Dataloder work as expected.

closes #29