### PR TITLE
Error Management

### DIFF
--- a/lib/rk_backend/logic/auth/sign_in.ex
+++ b/lib/rk_backend/logic/auth/sign_in.ex
@@ -47,6 +47,8 @@ defmodule RkBackend.Logic.Auth.SignIn do
       user = Repo.preload(user, :role)
       SessionService.start(user, token)
       {:ok, Map.merge(user, %{token: token})}
+    else
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -65,7 +67,7 @@ defmodule RkBackend.Logic.Auth.SignIn do
     case SessionService.lookup({SessionService, user_id}) do
       {:ok, pid} ->
         SessionService.delete_session(pid)
-        {:ok, "Session Deleted"}
+        {:ok, :signed_out}
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/rk_backend/repo/auth.ex
+++ b/lib/rk_backend/repo/auth.ex
@@ -14,18 +14,18 @@ defmodule RkBackend.Repo.Auth do
   @doc """
   Gets a single user.
 
-  Raises `Ecto.NoResultsError` if the User does not exist.
+  Returns nil if not found
 
   ## Examples
 
-      iex> get_user!(123)
+      iex> get_user(123)
       %User{}
 
-      iex> get_user!(456)
-      ** (Ecto.NoResultsError)
+      iex> get_user(456)
+      nil
 
   """
-  def get_user!(id), do: Repo.get!(User, id)
+  def get_user(id), do: Repo.get(User, id)
 
   @doc """
   Stores an user.
@@ -73,7 +73,7 @@ defmodule RkBackend.Repo.Auth do
         |> Repo.update()
 
       nil ->
-        {:error, "User not found"}
+        {:error, :not_found}
     end
   end
 
@@ -107,7 +107,7 @@ defmodule RkBackend.Repo.Auth do
   """
   def find_user_by_email(email) when is_binary(email) do
     case Repo.get_by(User, email: email) do
-      nil -> {:error, "User not found"}
+      nil -> {:error, :not_found}
       user -> {:ok, user}
     end
   end
@@ -169,7 +169,7 @@ defmodule RkBackend.Repo.Auth do
         |> Repo.update()
 
       nil ->
-        {:error, "Role not found"}
+        {:error, :not_found}
     end
   end
 

--- a/lib/rk_backend/repo/complaint.ex
+++ b/lib/rk_backend/repo/complaint.ex
@@ -152,7 +152,7 @@ defmodule RkBackend.Repo.Complaint do
         |> Repo.update()
 
       nil ->
-        {:error, "Reklama not found"}
+        {:error, :not_found}
     end
   end
 
@@ -200,7 +200,7 @@ defmodule RkBackend.Repo.Complaint do
         |> Repo.update()
 
       nil ->
-        {:error, "Topic not found"}
+        {:error, :not_found}
     end
   end
 

--- a/lib/rk_backend_web/middlewares/auth.ex
+++ b/lib/rk_backend_web/middlewares/auth.ex
@@ -24,12 +24,12 @@ defmodule RkBackend.Middlewares.Auth do
 
       false ->
         resolution
-        |> Absinthe.Resolution.put_result({:error, "Not enough privileges"})
+        |> Absinthe.Resolution.put_result({:error, :not_authorized})
     end
   end
 
   def call(resolution, _config) do
     resolution
-    |> Absinthe.Resolution.put_result({:error, "Not authenticated"})
+    |> Absinthe.Resolution.put_result({:error, :not_authenticated})
   end
 end

--- a/lib/rk_backend_web/plugs/inject_detect.ex
+++ b/lib/rk_backend_web/plugs/inject_detect.ex
@@ -21,8 +21,8 @@ defmodule Plugs.InjectDetect do
       {:ok, context} ->
         put_private(conn, :absinthe, %{context: context})
 
-      {:error, reason} ->
-        conn |> send_resp(403, reason) |> halt()
+      {:error, reason} when is_atom(reason) ->
+        conn |> send_resp(403, Atom.to_string(reason)) |> halt()
 
       _ ->
         conn |> send_resp(400, "Bad request") |> halt()
@@ -44,17 +44,7 @@ defmodule Plugs.InjectDetect do
          {:ok, _pid} <- SessionService.lookup({SessionService, user_id}) do
       {:ok, user_id}
     else
-      {:error, :expired} ->
-        {:error, "Session Expired"}
-
-      {:error, :invalid} ->
-        {:error, "Invalid Token"}
-
-      {:error, :not_found} ->
-        {:error, "Session not found"}
-
-      {:error, reason} ->
-        {:error, reason}
+      error -> error
     end
   end
 end

--- a/lib/rk_backend_web/queries/auth_queries.ex
+++ b/lib/rk_backend_web/queries/auth_queries.ex
@@ -11,14 +11,12 @@ defmodule RkBackendWeb.Schema.Queries.AuthQueries do
     field :resolve_user, :user do
       middleware(RkBackend.Middlewares.Auth)
       resolve(&AuthResolvers.resolve_user/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Get a list of users"
     field :users, list_of(:user) do
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&AuthResolvers.list_users/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Get an user"
@@ -26,14 +24,12 @@ defmodule RkBackendWeb.Schema.Queries.AuthQueries do
       arg(:id, non_null(:integer))
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&AuthResolvers.get_user/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Get a list of available roles"
     field :roles, list_of(:role) do
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&AuthResolvers.list_roles/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
   end
 
@@ -43,21 +39,18 @@ defmodule RkBackendWeb.Schema.Queries.AuthQueries do
       arg(:email, non_null(:string))
       arg(:password, non_null(:string))
       resolve(&AuthResolvers.sign_in/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Sign Out"
     field :sign_out, :string do
       middleware(RkBackend.Middlewares.Auth)
       resolve(&AuthResolvers.sign_out/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Create an user"
     field :create_user, :user do
       arg(:user_details, non_null(:user_details))
       resolve(&AuthResolvers.store_user/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Update an user"
@@ -65,7 +58,6 @@ defmodule RkBackendWeb.Schema.Queries.AuthQueries do
       arg(:user_update_details, non_null(:user_update_details))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&AuthResolvers.update_user/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Update user ADMIN"
@@ -73,7 +65,6 @@ defmodule RkBackendWeb.Schema.Queries.AuthQueries do
       arg(:user_update_role, non_null(:user_update_role))
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&AuthResolvers.update_user/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Create a role"
@@ -81,7 +72,6 @@ defmodule RkBackendWeb.Schema.Queries.AuthQueries do
       arg(:type, non_null(:string))
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&AuthResolvers.store_role/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
   end
 end

--- a/lib/rk_backend_web/queries/complaint_queries.ex
+++ b/lib/rk_backend_web/queries/complaint_queries.ex
@@ -12,7 +12,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:id, non_null(:integer))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&ComplaintResolvers.get_reklama/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Get a list of reklamas"
@@ -23,7 +22,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:per_page, non_null(:integer))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&ComplaintResolvers.list_reklamas/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
   end
 
@@ -33,7 +31,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:reklama_details, non_null(:reklama_details))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&ComplaintResolvers.store_reklama/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Update a reklama"
@@ -41,7 +38,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:update_reklama_details, non_null(:update_reklama_details))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&ComplaintResolvers.update_reklama/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Delete a reklama"
@@ -49,7 +45,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:id, non_null(:integer))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&ComplaintResolvers.delete_reklama/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Create a topic"
@@ -57,7 +52,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:topic_details, non_null(:topic_details))
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&ComplaintResolvers.store_topic/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Update a topic"
@@ -65,7 +59,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:update_topic_details, non_null(:update_topic_details))
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&ComplaintResolvers.update_topic/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Delete a topic"
@@ -73,7 +66,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:id, non_null(:integer))
       middleware(RkBackend.Middlewares.Auth, ["ADMIN"])
       resolve(&ComplaintResolvers.delete_topic/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Create a message"
@@ -81,7 +73,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:message_details, non_null(:message_details))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&ComplaintResolvers.store_message/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
 
     @desc "Delete a message"
@@ -89,7 +80,6 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries do
       arg(:id, non_null(:integer))
       middleware(RkBackend.Middlewares.Auth)
       resolve(&ComplaintResolvers.delete_message/2)
-      middleware(RkBackend.Middlewares.HandleErrors)
     end
   end
 end

--- a/lib/rk_backend_web/resolvers/auth_resolvers.ex
+++ b/lib/rk_backend_web/resolvers/auth_resolvers.ex
@@ -15,10 +15,6 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
     SignIn.sign_in(email, password)
   end
 
-  def sign_in(_args, _info) do
-    {:error, "Arguments error"}
-  end
-
   def sign_out(_arg, %{context: %{user_id: user_id}}) do
     SignIn.sign_out(user_id)
   end
@@ -30,20 +26,16 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
   def resolve_user(_args, _context), do: {:error, "Not Authenticated"}
 
   def list_users(_args, _info) do
-    try do
-      {:ok, Repo.all(User)}
-    rescue
-      Ecto.NoResultsError ->
-        {:error, :rescued}
-    end
+    {:ok, Repo.all(User)}
   end
 
   def get_user(%{id: id} = _args, _info) do
-    try do
-      {:ok, Auth.get_user!(id)}
-    rescue
-      Ecto.NoResultsError ->
-        {:error, "ID: #{id} not found"}
+    case Auth.get_user(id) do
+      %User{} = user ->
+        {:ok, user}
+
+      nil ->
+        {:error, :not_found}
     end
   end
 
@@ -54,7 +46,6 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end
@@ -68,7 +59,6 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end
@@ -82,12 +72,7 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
   end
 
   def list_roles(_args, _info) do
-    try do
-      {:ok, Repo.all(Role)}
-    rescue
-      Ecto.NoResultsError ->
-        {:error, :rescued}
-    end
+    {:ok, Repo.all(Role)}
   end
 
   def store_role(args, _info) do
@@ -97,7 +82,6 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end

--- a/lib/rk_backend_web/resolvers/complaint_resolvers.ex
+++ b/lib/rk_backend_web/resolvers/complaint_resolvers.ex
@@ -6,8 +6,6 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   alias RkBackend.Repo.Complaint.Message
   alias RkBackend.Utils
 
-  require Logger
-
   @moduledoc """
   Module with resolvers for Complaint queries and mutations
   """
@@ -21,7 +19,6 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end
@@ -32,28 +29,22 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
         Repo.delete(reklama)
 
       nil ->
-        {:error, "Reklama not found"}
+        {:error, :not_found}
     end
   end
 
   def list_reklamas(args, _info) do
-    case validate_args(args) do
-      {:ok, args} ->
-        reklamas = Complaint.list_reklamas(args)
-        {:ok, reklamas}
-
-      {:error, msg} ->
-        {:error, msg}
-    end
+    reklamas = Complaint.list_reklamas(args)
+    {:ok, reklamas}
   end
 
   def get_reklama(%{id: id} = _args, _info) do
     case Repo.get(Reklama, id) do
-      {:ok, reklama} ->
+      %Reklama{} = reklama ->
         {:ok, reklama}
 
       nil ->
-        {:error, "This reklama could not be found"}
+        {:error, :not_found}
     end
   end
 
@@ -64,7 +55,6 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end
@@ -76,7 +66,6 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end
@@ -88,7 +77,6 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end
@@ -99,7 +87,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
         Repo.delete(topic)
 
       nil ->
-        {:error, "Topic not found"}
+        {:error, :not_found}
     end
   end
 
@@ -112,7 +100,6 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)
-        Logger.error(errors)
         {:error, errors}
     end
   end
@@ -123,23 +110,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
         Repo.delete(message)
 
       nil ->
-        {:error, "Message not found"}
+        {:error, :not_found}
     end
-  end
-
-  defp validate_args(args) do
-    errors =
-      []
-      |> validate_page(args)
-
-    if Enum.empty?(errors), do: {:ok, args}, else: {:error, errors}
-  end
-
-  defp validate_page(errors, %{page: page}) when page > 0 do
-    errors
-  end
-
-  defp validate_page(errors, _args) do
-    ["Page: must be bigger than 0" | errors]
   end
 end

--- a/lib/rk_backend_web/schema.ex
+++ b/lib/rk_backend_web/schema.ex
@@ -49,4 +49,8 @@ defmodule RkBackendWeb.Schema do
     import_fields(:auth_mutations)
     import_fields(:complaint_mutations)
   end
+
+  def middleware(middleware, _field, _object) do
+    Enum.map(middleware, &RkBackend.Middlewares.HandleErrors.add_error_handling/1)
+  end
 end

--- a/test/rk_backend/logic/auth/sign_in_test.exs
+++ b/test/rk_backend/logic/auth/sign_in_test.exs
@@ -59,7 +59,7 @@ defmodule RkBackend.Logic.Auth.SignInTest do
       user = user_fixture()
 
       assert {:ok, _token} = SignIn.sign_in(user.email, user.password)
-      assert {:ok, "Session Deleted"} = SignIn.sign_out(user.id)
+      assert {:ok, :signed_out} = SignIn.sign_out(user.id)
     end
 
     test "sign_out/2 unsuccessful" do

--- a/test/rk_backend/repo/auth/auth_test.exs
+++ b/test/rk_backend/repo/auth/auth_test.exs
@@ -81,7 +81,7 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "get_user!/1 returns the user with given id" do
       user = user_fixture()
-      assert Auth.get_user!(user.id).id == user.id
+      assert Auth.get_user(user.id).id == user.id
     end
 
     test "update_user/2 with valid data updates the user" do
@@ -131,7 +131,7 @@ defmodule RkBackend.Repo.AuthTest do
     test "delete_user/1 deletes the user" do
       user = user_fixture()
       assert {:ok, %User{}} = Auth.delete_user(user)
-      assert_raise Ecto.NoResultsError, fn -> Auth.get_user!(user.id) end
+      assert Auth.get_user(user.id) == nil
     end
 
     test "find_user_by_email/1 successful" do
@@ -140,7 +140,7 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "find_user_by_email/1 unsuccessful" do
-      assert {:error, "User not found"} = Auth.find_user_by_email("notFound@gmail.com")
+      assert {:error, :not_found} = Auth.find_user_by_email("notFound@gmail.com")
     end
   end
 


### PR DESCRIPTION
   - Try/rescue blocks were mostly removed from resolvers.
   - Middleware HandleErrors now handle exclusively exceptions, logging them and their stacktrace and capturing all exceptions inside the graphql's modules.
   - Logger was removed from resolver modules since it was logging exclusively validations and not unexpected exceptions.
   - Error tuples follow the next format now: {:error, :reason}. Strings are mostly not allowed

closes #25