### PR TITLE
Organize Code

### DIFF
--- a/lib/rk_backend/repo/auth.ex
+++ b/lib/rk_backend/repo/auth.ex
@@ -9,24 +9,6 @@ defmodule RkBackend.Repo.Auth do
   alias RkBackend.Repo.Auth.User
   alias RkBackend.Repo.Auth.Role
 
-  require Logger
-
-  @doc """
-  Gets a single user.
-
-  Returns nil if not found
-
-  ## Examples
-
-      iex> get_user(123)
-      %User{}
-
-      iex> get_user(456)
-      nil
-
-  """
-  def get_user(id), do: Repo.get(User, id)
-
   @doc """
   Stores an user.
 
@@ -78,22 +60,6 @@ defmodule RkBackend.Repo.Auth do
   end
 
   @doc """
-  Deletes an User.
-
-  ## Examples
-
-      iex> delete_user(user)
-      {:ok, %User{}}
-
-      iex> delete_user(user)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_user(%User{} = user) do
-    Repo.delete(user)
-  end
-
-  @doc """
   Returns an `%Auth.User{}` with the selected email.
 
   ## Examples
@@ -111,22 +77,6 @@ defmodule RkBackend.Repo.Auth do
       user -> {:ok, user}
     end
   end
-
-  @doc """
-  Gets a single role.
-
-  Raises `Ecto.NoResultsError` if the Role does not exist.
-
-  ## Examples
-
-      iex> get_role!(123)
-      %Role{}
-
-      iex> get_role!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_role!(id), do: Repo.get!(Role, id)
 
   @doc """
   Stores a role.
@@ -171,21 +121,5 @@ defmodule RkBackend.Repo.Auth do
       nil ->
         {:error, :not_found}
     end
-  end
-
-  @doc """
-  Deletes a Role.
-
-  ## Examples
-
-      iex> delete_role(role)
-      {:ok, %Role{}}
-
-      iex> delete_role(role)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_role(%Role{} = role) do
-    Repo.delete(role)
   end
 end

--- a/lib/rk_backend/repo/complaint.ex
+++ b/lib/rk_backend/repo/complaint.ex
@@ -10,8 +10,6 @@ defmodule RkBackend.Repo.Complaint do
   alias RkBackend.Repo.Complaint.Topic
   alias RkBackend.Repo.Complaint.Message
 
-  require Logger
-
   @doc """
   Stores a reklama.
 

--- a/lib/rk_backend_web/resolvers/auth_resolvers.ex
+++ b/lib/rk_backend_web/resolvers/auth_resolvers.ex
@@ -31,7 +31,7 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
   end
 
   def get_user(%{id: id} = _args, _info) do
-    case Auth.get_user(id) do
+    case Repo.get(User, id) do
       %User{} = user ->
         {:ok, user}
 
@@ -82,8 +82,8 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
 
   def store_role(args, _info) do
     case Auth.store_role(args) do
-      {:ok, changeset} ->
-        {:ok, changeset}
+      {:ok, role} ->
+        {:ok, role}
 
       {:error, errors} ->
         errors = Utils.errors_to_string(errors)

--- a/lib/rk_backend_web/resolvers/complaint_resolvers.ex
+++ b/lib/rk_backend_web/resolvers/complaint_resolvers.ex
@@ -12,10 +12,11 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   """
 
   def store_reklama(args, %{context: %{user_id: user_id}}) do
-    args = Map.put(args.reklama_details, :user_id, user_id)
-    args = put_images(args)
-
-    case Complaint.store_reklama(args) do
+    args.reklama_details
+    |> Map.put(:user_id, user_id)
+    |> put_images()
+    |> Complaint.store_reklama()
+    |> case do
       {:ok, reklama} ->
         {:ok, reklama}
 
@@ -103,9 +104,10 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   end
 
   def store_message(args, %{context: %{user_id: user_id}}) do
-    args = Map.put(args.message_details, :user_id, user_id)
-
-    case Complaint.store_message(args) do
+    args.message_details
+    |> Map.put(:user_id, user_id)
+    |> Complaint.store_message()
+    |> case do
       {:ok, message} ->
         {:ok, message}
 
@@ -125,7 +127,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
     end
   end
 
-  def put_images(%{images: images} = args) do
+  defp put_images(%{images: images} = args) do
     args
     |> Map.put(
       :images,
@@ -133,7 +135,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
     )
   end
 
-  def put_images(args) do
+  defp put_images(args) do
     args
   end
 end

--- a/test/rk_backend/repo/auth/auth_test.exs
+++ b/test/rk_backend/repo/auth/auth_test.exs
@@ -81,7 +81,7 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "get_user!/1 returns the user with given id" do
       user = user_fixture()
-      assert Auth.get_user(user.id).id == user.id
+      assert Repo.get(User, user.id).id == user.id
     end
 
     test "update_user/2 with valid data updates the user" do
@@ -144,8 +144,8 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "delete_user/1 deletes the user" do
       user = user_fixture()
-      assert {:ok, %User{}} = Auth.delete_user(user)
-      assert Auth.get_user(user.id) == nil
+      assert {:ok, %User{}} = Repo.delete(user)
+      assert Repo.get(User, user.id) == nil
     end
 
     test "find_user_by_email/1 successful" do
@@ -174,7 +174,7 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "get_role!/1 returns the role with given id" do
       role = role_fixture()
-      assert Auth.get_role!(role.id) == role
+      assert Repo.get(Role, role.id) == role
     end
 
     test "store_role/1 with valid data creates a role" do
@@ -214,12 +214,6 @@ defmodule RkBackend.Repo.AuthTest do
         |> Map.put(:id, role.id)
 
       assert {:error, %Ecto.Changeset{}} = Auth.update_role(invalid_args)
-    end
-
-    test "delete_role/1 deletes the role" do
-      role = role_fixture()
-      assert {:ok, %Role{}} = Auth.delete_role(role)
-      assert_raise Ecto.NoResultsError, fn -> Auth.get_role!(role.id) end
     end
   end
 end


### PR DESCRIPTION
   - Some functions were made private.
   - Functions that could be changed for a call to a single Repo's method, were removed.
   - Resolvers now use mostly pipelines instead of passing variables from one method to another.
   - Unused 'import Logger' were removed.
   - Unused methods were removed, like remove_user and remove_role

closes #39