### PR TITLE
Reorganize Repo Code

### DIFF
--- a/lib/rk_backend/auth/session_service.ex
+++ b/lib/rk_backend/auth/session_service.ex
@@ -1,8 +1,8 @@
-defmodule RkBackend.Logic.Auth.SessionService do
+defmodule RkBackend.Auth.SessionService do
   use GenServer, restart: :transient
 
-  alias RkBackend.Repo.Auth.User
-  alias RkBackend.Logic.Auth.SignIn
+  alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Auth.SignIn
 
   defstruct user: nil, token: nil
 

--- a/lib/rk_backend/auth/sign_in.ex
+++ b/lib/rk_backend/auth/sign_in.ex
@@ -1,9 +1,9 @@
-defmodule RkBackend.Logic.Auth.SignIn do
-  alias RkBackend.Repo.Auth
+defmodule RkBackend.Auth.SignIn do
+  alias RkBackend.Repo.Auth.Users
   alias Argon2
   alias Phoenix.Token
   alias RkBackend.Repo
-  alias RkBackend.Logic.Auth.SessionService
+  alias RkBackend.Auth.SessionService
 
   @moduledoc """
   Provides functions related with the user's login
@@ -40,7 +40,7 @@ defmodule RkBackend.Logic.Auth.SignIn do
       {:error, reason}
   """
   def sign_in(email, password) do
-    with {:ok, user} <- Auth.find_user_by_email(email),
+    with {:ok, user} <- Users.find_user_by_email(email),
          {:ok, user} <- Argon2.check_pass(user, password) do
       token = Token.sign(@secret, @salt, user.id)
 

--- a/lib/rk_backend/repo/auth/roles.ex
+++ b/lib/rk_backend/repo/auth/roles.ex
@@ -1,0 +1,55 @@
+defmodule RkBackend.Repo.Auth.Roles do
+  import Ecto.Query, warn: false
+
+  alias RkBackend.Repo
+  alias RkBackend.Repo.Auth.Schemas.Role
+
+  @moduledoc """
+  Provide functions to manage Roles.
+  """
+
+  @doc """
+  Stores a role.
+
+  ## Examples
+
+      iex> store_role(%{field: value})
+      {:ok, %Role{}}
+
+      iex> store_role(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def store_role(args) do
+    %Role{}
+    |> Role.changeset(args)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a role.
+
+  ## Examples
+
+      iex> update_role(role, %{field: new_value})
+      {:ok, %Role{}}
+
+      iex> update_role(role, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_role(args) do
+    {id, args} = Map.pop(args, :id)
+
+    case Repo.get(Role, id) do
+      %Role{} = role ->
+        role
+        |> Repo.dynamically_preload(args)
+        |> Role.changeset(args)
+        |> Repo.update()
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+end

--- a/lib/rk_backend/repo/auth/schemas/role.ex
+++ b/lib/rk_backend/repo/auth/schemas/role.ex
@@ -1,6 +1,8 @@
-defmodule RkBackend.Repo.Auth.Role do
+defmodule RkBackend.Repo.Auth.Schemas.Role do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias RkBackend.Repo.Auth.Schemas.User
 
   @moduledoc """
   Role Entity and basic functions
@@ -11,7 +13,7 @@ defmodule RkBackend.Repo.Auth.Role do
 
     timestamps()
 
-    has_many :users, RkBackend.Repo.Auth.User
+    has_many :users, User
   end
 
   @required [:type]

--- a/lib/rk_backend/repo/auth/schemas/user.ex
+++ b/lib/rk_backend/repo/auth/schemas/user.ex
@@ -1,6 +1,10 @@
-defmodule RkBackend.Repo.Auth.User do
+defmodule RkBackend.Repo.Auth.Schemas.User do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias RkBackend.Repo.Auth.Schemas.Role
+  alias RkBackend.Repo.Complaint.Schemas.Reklama
+  alias RkBackend.Repo.Complaint.Schemas.Message
 
   @moduledoc """
   User Entity and basic functions
@@ -15,9 +19,9 @@ defmodule RkBackend.Repo.Auth.User do
     field :avatar_name, :string
     field :avatar, :binary
 
-    belongs_to :role, RkBackend.Repo.Auth.Role
-    has_many :reklamas, RkBackend.Repo.Complaint.Reklama
-    has_many :messages, RkBackend.Repo.Complaint.Message
+    belongs_to :role, Role
+    has_many :reklamas, Reklama
+    has_many :messages, Message
 
     timestamps()
   end
@@ -30,7 +34,7 @@ defmodule RkBackend.Repo.Auth.User do
     |> cast(args, @required ++ @optional)
     |> validate_required(@required)
     |> unique_constraint(:email)
-    |> validate_confirmation(:password, message: "does not match password")
+    |> validate_confirmation(:password, message: "password does not match")
     |> foreign_key_constraint(:role_id)
     |> put_password_hash
   end

--- a/lib/rk_backend/repo/auth/users.ex
+++ b/lib/rk_backend/repo/auth/users.ex
@@ -1,13 +1,13 @@
-defmodule RkBackend.Repo.Auth do
-  @moduledoc """
-  Provide functions to manage Auth entities.
-  """
-
+defmodule RkBackend.Repo.Auth.Users do
   import Ecto.Query, warn: false
 
   alias RkBackend.Repo
-  alias RkBackend.Repo.Auth.User
-  alias RkBackend.Repo.Auth.Role
+  alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Repo.Auth.Schemas.Role
+
+  @moduledoc """
+  Provide functions to manage Users.
+  """
 
   @doc """
   Stores an user.
@@ -75,51 +75,6 @@ defmodule RkBackend.Repo.Auth do
     case Repo.get_by(User, email: email) do
       nil -> {:error, :not_found}
       user -> {:ok, user}
-    end
-  end
-
-  @doc """
-  Stores a role.
-
-  ## Examples
-
-      iex> store_role(%{field: value})
-      {:ok, %Role{}}
-
-      iex> store_role(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def store_role(args) do
-    %Role{}
-    |> Role.changeset(args)
-    |> Repo.insert()
-  end
-
-  @doc """
-  Updates a role.
-
-  ## Examples
-
-      iex> update_role(role, %{field: new_value})
-      {:ok, %Role{}}
-
-      iex> update_role(role, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def update_role(args) do
-    {id, args} = Map.pop(args, :id)
-
-    case Repo.get(Role, id) do
-      %Role{} = role ->
-        role
-        |> Repo.dynamically_preload(args)
-        |> Role.changeset(args)
-        |> Repo.update()
-
-      nil ->
-        {:error, :not_found}
     end
   end
 end

--- a/lib/rk_backend/repo/complaint/messages.ex
+++ b/lib/rk_backend/repo/complaint/messages.ex
@@ -1,0 +1,28 @@
+defmodule RkBackend.Repo.Complaint.Messages do
+  import Ecto.Query, warn: false
+
+  alias RkBackend.Repo
+  alias RkBackend.Repo.Complaint.Schemas.Message
+
+  @moduledoc """
+  Provide functions to manage Messages.
+  """
+
+  @doc """
+  Stores a message.
+
+  ## Examples
+
+      iex> store_message(%{field: value})
+      {:ok, %Message{}}
+
+      iex> store_message(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def store_message(args) do
+    %Message{}
+    |> Message.changeset(args)
+    |> Repo.insert()
+  end
+end

--- a/lib/rk_backend/repo/complaint/reklamas.ex
+++ b/lib/rk_backend/repo/complaint/reklamas.ex
@@ -1,14 +1,12 @@
-defmodule RkBackend.Repo.Complaint do
-  @moduledoc """
-  Provide functions to manage Complaint entities.
-  """
-
+defmodule RkBackend.Repo.Complaint.Reklamas do
   import Ecto.Query, warn: false
 
   alias RkBackend.Repo
-  alias RkBackend.Repo.Complaint.Reklama
-  alias RkBackend.Repo.Complaint.Topic
-  alias RkBackend.Repo.Complaint.Message
+  alias RkBackend.Repo.Complaint.Schemas.Reklama
+
+  @moduledoc """
+  Provide functions to manage Reklamas.
+  """
 
   @doc """
   Stores a reklama.
@@ -131,68 +129,5 @@ defmodule RkBackend.Repo.Complaint do
       nil ->
         {:error, :not_found}
     end
-  end
-
-  @doc """
-  Stores a topic.
-
-  ## Examples
-
-      iex> store_topic(%{field: value})
-      {:ok, %Topic{}}
-
-      iex> store_topic(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def store_topic(args) do
-    %Topic{}
-    |> Topic.changeset(args)
-    |> Repo.insert()
-  end
-
-  @doc """
-  Updates a topic
-
-  ## Examples
-
-      iex> update_topic(%{field: value})
-      {:ok, %Topic{}}
-
-      iex> update_topic(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def update_topic(args) do
-    {id, args} = Map.pop(args, :id)
-
-    case Repo.get(Topic, id) do
-      %Topic{} = topic ->
-        topic
-        |> Repo.dynamically_preload(args)
-        |> Topic.changeset(args)
-        |> Repo.update()
-
-      nil ->
-        {:error, :not_found}
-    end
-  end
-
-  @doc """
-  Stores a message.
-
-  ## Examples
-
-      iex> store_message(%{field: value})
-      {:ok, %Message{}}
-
-      iex> store_message(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def store_message(args) do
-    %Message{}
-    |> Message.changeset(args)
-    |> Repo.insert()
   end
 end

--- a/lib/rk_backend/repo/complaint/schemas/message.ex
+++ b/lib/rk_backend/repo/complaint/schemas/message.ex
@@ -1,6 +1,9 @@
-defmodule RkBackend.Repo.Complaint.Message do
+defmodule RkBackend.Repo.Complaint.Schemas.Message do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Repo.Complaint.Schemas.Reklama
 
   @moduledoc """
   Message Entity and basic functions
@@ -9,8 +12,8 @@ defmodule RkBackend.Repo.Complaint.Message do
   schema "messages" do
     field :content, :string
 
-    belongs_to :user, RkBackend.Repo.Auth.User
-    belongs_to :reklama, RkBackend.Repo.Complaint.Reklama
+    belongs_to :user, User
+    belongs_to :reklama, Reklama
 
     timestamps()
   end

--- a/lib/rk_backend/repo/complaint/schemas/reklama.ex
+++ b/lib/rk_backend/repo/complaint/schemas/reklama.ex
@@ -1,6 +1,11 @@
-defmodule RkBackend.Repo.Complaint.Reklama do
+defmodule RkBackend.Repo.Complaint.Schemas.Reklama do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Repo.Complaint.Schemas.Topic
+  alias RkBackend.Repo.Complaint.Schemas.Message
+  alias RkBackend.Repo.Complaint.Schemas.Reklama.ReklamaImage
 
   @moduledoc """
   Reklama Entity and basic functions
@@ -10,10 +15,10 @@ defmodule RkBackend.Repo.Complaint.Reklama do
     field :title, :string
     field :content, :string
 
-    belongs_to :user, RkBackend.Repo.Auth.User
-    belongs_to :topic, RkBackend.Repo.Complaint.Topic
-    has_many :messages, RkBackend.Repo.Complaint.Message
-    has_many :images, RkBackend.Repo.Complaint.Reklama.ReklamaImage, on_replace: :delete
+    belongs_to :user, User
+    belongs_to :topic, Topic
+    has_many :messages, Message
+    has_many :images, ReklamaImage, on_replace: :delete
 
     timestamps()
   end

--- a/lib/rk_backend/repo/complaint/schemas/reklama/reklama_image.ex
+++ b/lib/rk_backend/repo/complaint/schemas/reklama/reklama_image.ex
@@ -1,6 +1,8 @@
-defmodule RkBackend.Repo.Complaint.Reklama.ReklamaImage do
+defmodule RkBackend.Repo.Complaint.Schemas.Reklama.ReklamaImage do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias RkBackend.Repo.Complaint.Schemas.Reklama
 
   @moduledoc """
   ReklamaImage Entity and basic functions
@@ -10,7 +12,7 @@ defmodule RkBackend.Repo.Complaint.Reklama.ReklamaImage do
     field :name, :string
     field :image, :binary
 
-    belongs_to :reklama, RkBackend.Repo.Complaint.Reklama
+    belongs_to :reklama, Reklama
 
     timestamps()
   end

--- a/lib/rk_backend/repo/complaint/schemas/topic.ex
+++ b/lib/rk_backend/repo/complaint/schemas/topic.ex
@@ -1,6 +1,8 @@
-defmodule RkBackend.Repo.Complaint.Topic do
+defmodule RkBackend.Repo.Complaint.Schemas.Topic do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias RkBackend.Repo.Complaint.Schemas.Reklama
 
   @moduledoc """
   Topic Entity and basic functions
@@ -12,7 +14,7 @@ defmodule RkBackend.Repo.Complaint.Topic do
     field :image_name, :string
     field :image, :binary
 
-    has_many :reklamas, RkBackend.Repo.Complaint.Reklama
+    has_many :reklamas, Reklama
 
     timestamps()
   end

--- a/lib/rk_backend/repo/complaint/topics.ex
+++ b/lib/rk_backend/repo/complaint/topics.ex
@@ -1,0 +1,55 @@
+defmodule RkBackend.Repo.Complaint.Topics do
+  import Ecto.Query, warn: false
+
+  alias RkBackend.Repo
+  alias RkBackend.Repo.Complaint.Schemas.Topic
+
+  @moduledoc """
+  Provide functions to manage Topics.
+  """
+
+  @doc """
+  Stores a topic.
+
+  ## Examples
+
+      iex> store_topic(%{field: value})
+      {:ok, %Topic{}}
+
+      iex> store_topic(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def store_topic(args) do
+    %Topic{}
+    |> Topic.changeset(args)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a topic
+
+  ## Examples
+
+      iex> update_topic(%{field: value})
+      {:ok, %Topic{}}
+
+      iex> update_topic(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_topic(args) do
+    {id, args} = Map.pop(args, :id)
+
+    case Repo.get(Topic, id) do
+      %Topic{} = topic ->
+        topic
+        |> Repo.dynamically_preload(args)
+        |> Topic.changeset(args)
+        |> Repo.update()
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+end

--- a/lib/rk_backend_web/middlewares/auth.ex
+++ b/lib/rk_backend_web/middlewares/auth.ex
@@ -5,7 +5,7 @@ defmodule RkBackend.Middlewares.Auth do
   Middleware used to detect if an user is authenticated and has enough privileges
   """
 
-  alias RkBackend.Logic.Auth.SessionService
+  alias RkBackend.Auth.SessionService
 
   def init(opts) do
     opts

--- a/lib/rk_backend_web/plugs/inject_detect.ex
+++ b/lib/rk_backend_web/plugs/inject_detect.ex
@@ -7,8 +7,8 @@ defmodule Plugs.InjectDetect do
 
   import Plug.Conn
 
-  alias RkBackend.Logic.Auth.SignIn
-  alias RkBackend.Logic.Auth.SessionService
+  alias RkBackend.Auth.SignIn
+  alias RkBackend.Auth.SessionService
 
   @impl Plug
   def init(opts) do

--- a/lib/rk_backend_web/resolvers/auth_resolvers.ex
+++ b/lib/rk_backend_web/resolvers/auth_resolvers.ex
@@ -1,8 +1,9 @@
 defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
   alias RkBackend.Repo
-  alias RkBackend.Repo.Auth
-  alias RkBackend.Repo.Auth.User
-  alias RkBackend.Logic.Auth.SignIn
+  alias RkBackend.Repo.Auth.Users
+  alias RkBackend.Repo.Auth.Roles
+  alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Auth.SignIn
   alias RkBackend.Utils
   alias RkBackendWeb.Schema
 
@@ -43,7 +44,7 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
   def store_user(args, _info) do
     args.user_details
     |> Schema.put_upload(file_bytes: :avatar, filename: :avatar_name)
-    |> Auth.store_user()
+    |> Users.store_user()
     |> case do
       {:ok, user} ->
         {:ok, user}
@@ -57,7 +58,7 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
   def update_user(args, _info) do
     get_user_update_details(args)
     |> Schema.put_upload(file_bytes: :avatar, filename: :avatar_name)
-    |> Auth.update_user()
+    |> Users.update_user()
     |> case do
       {:ok, user} ->
         {:ok, user}
@@ -81,7 +82,7 @@ defmodule RkBackendWeb.Schema.Resolvers.AuthResolvers do
   end
 
   def store_role(args, _info) do
-    case Auth.store_role(args) do
+    case Roles.store_role(args) do
       {:ok, role} ->
         {:ok, role}
 

--- a/lib/rk_backend_web/resolvers/complaint_resolvers.ex
+++ b/lib/rk_backend_web/resolvers/complaint_resolvers.ex
@@ -1,9 +1,11 @@
 defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   alias RkBackend.Repo
-  alias RkBackend.Repo.Complaint
-  alias RkBackend.Repo.Complaint.Reklama
-  alias RkBackend.Repo.Complaint.Topic
-  alias RkBackend.Repo.Complaint.Message
+  alias RkBackend.Repo.Complaint.Reklamas
+  alias RkBackend.Repo.Complaint.Topics
+  alias RkBackend.Repo.Complaint.Messages
+  alias RkBackend.Repo.Complaint.Schemas.Reklama
+  alias RkBackend.Repo.Complaint.Schemas.Topic
+  alias RkBackend.Repo.Complaint.Schemas.Message
   alias RkBackend.Utils
   alias RkBackendWeb.Schema
 
@@ -15,7 +17,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
     args.reklama_details
     |> Map.put(:user_id, user_id)
     |> put_images()
-    |> Complaint.store_reklama()
+    |> Reklamas.store_reklama()
     |> case do
       {:ok, reklama} ->
         {:ok, reklama}
@@ -37,7 +39,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   end
 
   def list_reklamas(args, _info) do
-    reklamas = Complaint.list_reklamas(args)
+    reklamas = Reklamas.list_reklamas(args)
     {:ok, reklamas}
   end
 
@@ -54,7 +56,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   def update_reklama(args, _info) do
     args.update_reklama_details
     |> put_images()
-    |> Complaint.update_reklama()
+    |> Reklamas.update_reklama()
     |> case do
       {:ok, reklama} ->
         {:ok, reklama}
@@ -68,7 +70,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   def store_topic(args, _info) do
     args.topic_details
     |> Schema.put_upload(file_bytes: :image, filename: :image_name)
-    |> Complaint.store_topic()
+    |> Topics.store_topic()
     |> case do
       {:ok, topic} ->
         {:ok, topic}
@@ -82,7 +84,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   def update_topic(args, _info) do
     args.topic_details
     |> Schema.put_upload(file_bytes: :image, filename: :image_name)
-    |> Complaint.update_topic()
+    |> Topics.update_topic()
     |> case do
       {:ok, topic} ->
         {:ok, topic}
@@ -106,7 +108,7 @@ defmodule RkBackendWeb.Schema.Resolvers.ComplaintResolvers do
   def store_message(args, %{context: %{user_id: user_id}}) do
     args.message_details
     |> Map.put(:user_id, user_id)
-    |> Complaint.store_message()
+    |> Messages.store_message()
     |> case do
       {:ok, message} ->
         {:ok, message}

--- a/priv/repo/migrations/20190501125321_create_roles.exs
+++ b/priv/repo/migrations/20190501125321_create_roles.exs
@@ -1,6 +1,8 @@
 defmodule RkBackend.Repo.Migrations.CreateRoles do
   use Ecto.Migration
 
+  alias RkBackend.Repo.Auth
+
   def change do
     create table(:roles) do
       add :type, :string, null: false
@@ -9,5 +11,18 @@ defmodule RkBackend.Repo.Migrations.CreateRoles do
     end
 
     create unique_index(:roles, [:type])
+
+    flush()
+
+    # Basic Roles
+    [
+      %{
+        type: "USER"
+      },
+      %{
+        type: "ADMIN"
+      }
+    ]
+    |> Enum.each(fn role -> Auth.store_role(role) end)
   end
 end

--- a/priv/repo/migrations/20190501125321_create_roles.exs
+++ b/priv/repo/migrations/20190501125321_create_roles.exs
@@ -1,7 +1,7 @@
 defmodule RkBackend.Repo.Migrations.CreateRoles do
   use Ecto.Migration
 
-  alias RkBackend.Repo.Auth
+  alias RkBackend.Repo.Auth.Roles
 
   def change do
     create table(:roles) do
@@ -23,6 +23,6 @@ defmodule RkBackend.Repo.Migrations.CreateRoles do
         type: "ADMIN"
       }
     ]
-    |> Enum.each(fn role -> Auth.store_role(role) end)
+    |> Enum.each(fn role -> Roles.store_role(role) end)
   end
 end

--- a/priv/repo/migrations/20190514211046_create_users.exs
+++ b/priv/repo/migrations/20190514211046_create_users.exs
@@ -1,7 +1,7 @@
 defmodule RkBackend.Repo.Migrations.CreateUsers do
   use Ecto.Migration
 
-  alias RkBackend.Repo.Auth
+  alias RkBackend.Repo.Auth.Users
 
   def change do
     create table(:users) do
@@ -27,6 +27,6 @@ defmodule RkBackend.Repo.Migrations.CreateUsers do
       password: "adminRK",
       password_confirmation: "adminRK"
     }
-    |> Auth.store_user()
+    |> Users.store_user()
   end
 end

--- a/priv/repo/migrations/20190514211046_create_users.exs
+++ b/priv/repo/migrations/20190514211046_create_users.exs
@@ -1,6 +1,8 @@
 defmodule RkBackend.Repo.Migrations.CreateUsers do
   use Ecto.Migration
 
+  alias RkBackend.Repo.Auth
+
   def change do
     create table(:users) do
       add :full_name, :string, null: false
@@ -15,5 +17,16 @@ defmodule RkBackend.Repo.Migrations.CreateUsers do
     end
 
     create unique_index(:users, [:email])
+
+    flush()
+
+    # Basic Admin user
+    %{
+      full_name: "admin",
+      email: "admin@rk.com",
+      password: "adminRK",
+      password_confirmation: "adminRK"
+    }
+    |> Auth.store_user()
   end
 end

--- a/priv/repo/migrations/20200319200349_create_reklamas.exs
+++ b/priv/repo/migrations/20200319200349_create_reklamas.exs
@@ -6,7 +6,7 @@ defmodule RkBackend.Repo.Migrations.CreateReklamas do
       add :title, :string, null: false, null: false
       add :content, :string, null: false, null: false
 
-      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :user_id, references(:users), null: false
       add :topic_id, references(:topics, on_delete: :delete_all), null: false
 
       timestamps()

--- a/test/rk_backend/auth/session_service_test.exs
+++ b/test/rk_backend/auth/session_service_test.exs
@@ -2,23 +2,14 @@ defmodule RkBackend.Auth.SessionServiceTest do
   use ExUnit.Case
 
   alias RkBackend.Auth.SessionService
+  alias RkBackend.Repo
   alias RkBackend.Repo.Auth.Schemas.User
   alias RkBackend.Repo.Auth.Schemas.Role
-  alias RkBackend.Repo.Auth.Roles
 
   @process {SessionService, 8080}
   @user %User{
     id: 8080
   }
-
-  def role_fixture(args \\ %{}) do
-    {:ok, role} =
-      args
-      |> Enum.into(%{type: "ADMIN"})
-      |> Roles.store_role()
-
-    role
-  end
 
   setup_all do
     # Explicitly get a connection before each test
@@ -26,7 +17,7 @@ defmodule RkBackend.Auth.SessionServiceTest do
     # Setting the shared mode must be done only after checkout
     Ecto.Adapters.SQL.Sandbox.mode(RkBackend.Repo, {:shared, self()})
 
-    state = %{@user | role: role_fixture()}
+    state = %{@user | role: Repo.get_by(Role, type: "USER")}
     {:ok, server_pid} = SessionService.start(state, "demoToken")
     {:ok, server: server_pid}
   end

--- a/test/rk_backend/auth/session_service_test.exs
+++ b/test/rk_backend/auth/session_service_test.exs
@@ -1,10 +1,10 @@
-defmodule RkBackend.Logic.Auth.SessionServiceTest do
+defmodule RkBackend.Auth.SessionServiceTest do
   use ExUnit.Case
 
-  alias RkBackend.Logic.Auth.SessionService
-  alias RkBackend.Repo.Auth.User
-  alias RkBackend.Repo.Auth.Role
-  alias RkBackend.Repo.Auth
+  alias RkBackend.Auth.SessionService
+  alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Repo.Auth.Schemas.Role
+  alias RkBackend.Repo.Auth.Roles
 
   @process {SessionService, 8080}
   @user %User{
@@ -15,7 +15,7 @@ defmodule RkBackend.Logic.Auth.SessionServiceTest do
     {:ok, role} =
       args
       |> Enum.into(%{type: "ADMIN"})
-      |> Auth.store_role()
+      |> Roles.store_role()
 
     role
   end

--- a/test/rk_backend/auth/sign_in_test.exs
+++ b/test/rk_backend/auth/sign_in_test.exs
@@ -1,8 +1,10 @@
-defmodule RkBackend.Logic.Auth.SignInTest do
+defmodule RkBackend.Auth.SignInTest do
   use RkBackend.DataCase
 
-  alias RkBackend.Logic.Auth.SignIn
-  alias RkBackend.Repo.Auth
+  alias RkBackend.Auth.SignIn
+  alias RkBackend.Repo.Auth.Users
+  alias RkBackend.Repo.Auth.Roles
+  alias RkBackend.Repo.Auth.Schemas.User
 
   describe "SignIn" do
     @valid_args_role %{type: "USER"}
@@ -18,7 +20,7 @@ defmodule RkBackend.Logic.Auth.SignInTest do
       {:ok, role} =
         args
         |> Enum.into(@valid_args_role)
-        |> Auth.store_role()
+        |> Roles.store_role()
 
       role
     end
@@ -33,7 +35,7 @@ defmodule RkBackend.Logic.Auth.SignInTest do
       {:ok, user} =
         args
         |> Enum.into(valid_args)
-        |> Auth.store_user()
+        |> Users.store_user()
 
       user
     end
@@ -52,7 +54,7 @@ defmodule RkBackend.Logic.Auth.SignInTest do
       user = user_fixture()
 
       assert {:ok, _token} = SignIn.sign_in(user.email, user.password)
-      assert {:ok, %Auth.User{}} = SignIn.resolve_user(user.id)
+      assert {:ok, %User{}} = SignIn.resolve_user(user.id)
     end
 
     test "sign_out/2 successful" do

--- a/test/rk_backend/auth/sign_in_test.exs
+++ b/test/rk_backend/auth/sign_in_test.exs
@@ -1,14 +1,13 @@
 defmodule RkBackend.Auth.SignInTest do
   use RkBackend.DataCase
 
+  alias RkBackend.Repo
   alias RkBackend.Auth.SignIn
   alias RkBackend.Repo.Auth.Users
-  alias RkBackend.Repo.Auth.Roles
   alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Repo.Auth.Schemas.Role
 
   describe "SignIn" do
-    @valid_args_role %{type: "USER"}
-
     @valid_args_user %{
       email: "some email",
       full_name: "some full_name",
@@ -16,17 +15,8 @@ defmodule RkBackend.Auth.SignInTest do
       password_confirmation: "password"
     }
 
-    def role_fixture(args \\ %{}) do
-      {:ok, role} =
-        args
-        |> Enum.into(@valid_args_role)
-        |> Roles.store_role()
-
-      role
-    end
-
     def user_fixture(args \\ %{}) do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
 
       valid_args =
         @valid_args_user

--- a/test/rk_backend/repo/auth/auth_test.exs
+++ b/test/rk_backend/repo/auth/auth_test.exs
@@ -1,6 +1,7 @@
 defmodule RkBackend.Repo.AuthTest do
   use RkBackend.DataCase
 
+  alias RkBackend.Repo
   alias RkBackend.Repo.Auth.Roles
   alias RkBackend.Repo.Auth.Users
   alias RkBackend.Repo.Auth.Schemas.Role
@@ -27,7 +28,7 @@ defmodule RkBackend.Repo.AuthTest do
     }
 
     def user_fixture(args \\ %{}) do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
 
       valid_args =
         @valid_args
@@ -42,7 +43,7 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "store_user/1 with valid data creates a user" do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
 
       valid_args =
         @valid_args
@@ -56,13 +57,11 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "store_user/1 with invalid data returns error changeset" do
-      role_fixture()
-
       assert {:error, %Ecto.Changeset{}} = Users.store_user(@invalid_args)
     end
 
     test "store_user/3 successful" do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
 
       valid_args =
         @valid_args
@@ -74,8 +73,6 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "store_user/3 unsuccessful" do
-      role_fixture()
-
       args = %{user_details: @invalid_args}
       assert {:error, changeset} = Users.store_user(args)
     end
@@ -160,27 +157,18 @@ defmodule RkBackend.Repo.AuthTest do
   end
 
   describe "roles" do
-    @valid_args %{type: "USER"}
+    @valid_args %{type: "NEW_ROLE"}
     @update_args %{type: "some updated type"}
     @invalid_args %{type: nil}
 
-    def role_fixture(args \\ %{}) do
-      {:ok, role} =
-        args
-        |> Enum.into(@valid_args)
-        |> Roles.store_role()
-
-      role
-    end
-
     test "get_role!/1 returns the role with given id" do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
       assert Repo.get(Role, role.id) == role
     end
 
     test "store_role/1 with valid data creates a role" do
       assert {:ok, %Role{} = role} = Roles.store_role(@valid_args)
-      assert role.type == "USER"
+      assert role.type == "NEW_ROLE"
     end
 
     test "store_role/1 with invalid data returns error changeset" do
@@ -189,7 +177,7 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "store_role/3 successful" do
       assert {:ok, %Role{} = role} = Roles.store_role(@valid_args)
-      assert role.type == "USER"
+      assert role.type == "NEW_ROLE"
     end
 
     test "store_role/3 unsuccessful" do
@@ -197,7 +185,7 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "update_role/2 with valid data updates the role" do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
 
       update_args =
         @update_args
@@ -208,7 +196,7 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "update_role/2 with invalid data returns error changeset" do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
 
       invalid_args =
         @invalid_args

--- a/test/rk_backend/repo/auth/auth_test.exs
+++ b/test/rk_backend/repo/auth/auth_test.exs
@@ -1,9 +1,10 @@
 defmodule RkBackend.Repo.AuthTest do
   use RkBackend.DataCase
 
-  alias RkBackend.Repo.Auth
-  alias RkBackend.Repo.Auth.Role
-  alias RkBackend.Repo.Auth.User
+  alias RkBackend.Repo.Auth.Roles
+  alias RkBackend.Repo.Auth.Users
+  alias RkBackend.Repo.Auth.Schemas.Role
+  alias RkBackend.Repo.Auth.Schemas.User
 
   describe "users" do
     @valid_args %{
@@ -35,7 +36,7 @@ defmodule RkBackend.Repo.AuthTest do
       {:ok, user} =
         args
         |> Enum.into(valid_args)
-        |> Auth.store_user()
+        |> Users.store_user()
 
       user
     end
@@ -47,7 +48,7 @@ defmodule RkBackend.Repo.AuthTest do
         @valid_args
         |> Map.put(:role_id, role.id)
 
-      assert {:ok, %User{} = user} = Auth.store_user(valid_args)
+      assert {:ok, %User{} = user} = Users.store_user(valid_args)
       assert user.email == "some email"
       assert user.full_name == "some full_name"
       assert user.password == "password"
@@ -57,7 +58,7 @@ defmodule RkBackend.Repo.AuthTest do
     test "store_user/1 with invalid data returns error changeset" do
       role_fixture()
 
-      assert {:error, %Ecto.Changeset{}} = Auth.store_user(@invalid_args)
+      assert {:error, %Ecto.Changeset{}} = Users.store_user(@invalid_args)
     end
 
     test "store_user/3 successful" do
@@ -67,7 +68,7 @@ defmodule RkBackend.Repo.AuthTest do
         @valid_args
         |> Map.put(:role_id, role.id)
 
-      assert {:ok, user = %User{}} = Auth.store_user(valid_args)
+      assert {:ok, user = %User{}} = Users.store_user(valid_args)
       assert user.role_id == role.id
       assert user.full_name == @valid_args.full_name
     end
@@ -76,7 +77,7 @@ defmodule RkBackend.Repo.AuthTest do
       role_fixture()
 
       args = %{user_details: @invalid_args}
-      assert {:error, changeset} = Auth.store_user(args)
+      assert {:error, changeset} = Users.store_user(args)
     end
 
     test "get_user!/1 returns the user with given id" do
@@ -91,7 +92,7 @@ defmodule RkBackend.Repo.AuthTest do
         @update_args
         |> Map.put(:id, user.id)
 
-      assert {:ok, %User{} = user} = Auth.update_user(update_args)
+      assert {:ok, %User{} = user} = Users.update_user(update_args)
       assert user.email == "some updated email"
       assert user.full_name == "some updated full_name"
     end
@@ -103,7 +104,7 @@ defmodule RkBackend.Repo.AuthTest do
         @invalid_args
         |> Map.put(:id, user.id)
 
-      assert {:error, %Ecto.Changeset{}} = Auth.update_user(invalid_args)
+      assert {:error, %Ecto.Changeset{}} = Users.update_user(invalid_args)
     end
 
     test "update_user/2 successful" do
@@ -113,7 +114,7 @@ defmodule RkBackend.Repo.AuthTest do
         @update_args
         |> Map.put(:id, user.id)
 
-      assert {:ok, user = %User{}} = Auth.update_user(update_args)
+      assert {:ok, user = %User{}} = Users.update_user(update_args)
       assert user.password == "password2"
     end
 
@@ -126,7 +127,7 @@ defmodule RkBackend.Repo.AuthTest do
         |> Map.put(:avatar_name, "avatar_name")
         |> Map.put(:avatar, <<25, 07, 15>>)
 
-      assert {:ok, user = %User{}} = Auth.update_user(update_args)
+      assert {:ok, user = %User{}} = Users.update_user(update_args)
       assert user.avatar_name == "avatar_name"
       assert user.avatar == <<25, 07, 15>>
     end
@@ -138,7 +139,7 @@ defmodule RkBackend.Repo.AuthTest do
         @invalid_args
         |> Map.put(:id, user.id)
 
-      assert {:error, reason} = Auth.update_user(update_args)
+      assert {:error, reason} = Users.update_user(update_args)
       assert reason = "password_confirmation: does not match password\n"
     end
 
@@ -150,11 +151,11 @@ defmodule RkBackend.Repo.AuthTest do
 
     test "find_user_by_email/1 successful" do
       user = user_fixture()
-      assert {:ok, %User{}} = Auth.find_user_by_email(user.email)
+      assert {:ok, %User{}} = Users.find_user_by_email(user.email)
     end
 
     test "find_user_by_email/1 unsuccessful" do
-      assert {:error, :not_found} = Auth.find_user_by_email("notFound@gmail.com")
+      assert {:error, :not_found} = Users.find_user_by_email("notFound@gmail.com")
     end
   end
 
@@ -167,7 +168,7 @@ defmodule RkBackend.Repo.AuthTest do
       {:ok, role} =
         args
         |> Enum.into(@valid_args)
-        |> Auth.store_role()
+        |> Roles.store_role()
 
       role
     end
@@ -178,21 +179,21 @@ defmodule RkBackend.Repo.AuthTest do
     end
 
     test "store_role/1 with valid data creates a role" do
-      assert {:ok, %Role{} = role} = Auth.store_role(@valid_args)
+      assert {:ok, %Role{} = role} = Roles.store_role(@valid_args)
       assert role.type == "USER"
     end
 
     test "store_role/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Auth.store_role(@invalid_args)
+      assert {:error, %Ecto.Changeset{}} = Roles.store_role(@invalid_args)
     end
 
     test "store_role/3 successful" do
-      assert {:ok, %Role{} = role} = Auth.store_role(@valid_args)
+      assert {:ok, %Role{} = role} = Roles.store_role(@valid_args)
       assert role.type == "USER"
     end
 
     test "store_role/3 unsuccessful" do
-      assert {:error, _reason} = Auth.store_role(@invalid_args)
+      assert {:error, _reason} = Roles.store_role(@invalid_args)
     end
 
     test "update_role/2 with valid data updates the role" do
@@ -202,7 +203,7 @@ defmodule RkBackend.Repo.AuthTest do
         @update_args
         |> Map.put(:id, role.id)
 
-      assert {:ok, %Role{} = role} = Auth.update_role(update_args)
+      assert {:ok, %Role{} = role} = Roles.update_role(update_args)
       assert role.type == "some updated type"
     end
 
@@ -213,7 +214,7 @@ defmodule RkBackend.Repo.AuthTest do
         @invalid_args
         |> Map.put(:id, role.id)
 
-      assert {:error, %Ecto.Changeset{}} = Auth.update_role(invalid_args)
+      assert {:error, %Ecto.Changeset{}} = Roles.update_role(invalid_args)
     end
   end
 end

--- a/test/rk_backend/repo/complaint/complaint_test.exs
+++ b/test/rk_backend/repo/complaint/complaint_test.exs
@@ -3,8 +3,8 @@ defmodule RkBackend.Repo.ComplaintTest do
 
   alias RkBackend.Repo
   alias RkBackend.Repo.Auth.Users
-  alias RkBackend.Repo.Auth.Roles
   alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Repo.Auth.Schemas.Role
   alias RkBackend.Repo.Complaint.Reklamas
   alias RkBackend.Repo.Complaint.Topics
   alias RkBackend.Repo.Complaint.Messages
@@ -66,7 +66,7 @@ defmodule RkBackend.Repo.ComplaintTest do
     end
 
     def user_fixture(args \\ %{}) do
-      role = role_fixture()
+      role = Repo.get_by(Role, type: "USER")
 
       valid_args =
         %{
@@ -83,15 +83,6 @@ defmodule RkBackend.Repo.ComplaintTest do
         |> Users.store_user()
 
       user
-    end
-
-    def role_fixture(args \\ %{}) do
-      {:ok, role} =
-        args
-        |> Enum.into(%{type: "USER"})
-        |> Roles.store_role()
-
-      role
     end
 
     test "store_reklama/0 simple" do

--- a/test/rk_backend/repo/complaint/complaint_test.exs
+++ b/test/rk_backend/repo/complaint/complaint_test.exs
@@ -2,12 +2,16 @@ defmodule RkBackend.Repo.ComplaintTest do
   use RkBackend.DataCase
 
   alias RkBackend.Repo
-  alias RkBackend.Repo.Auth
-  alias RkBackend.Repo.Complaint
-  alias RkBackend.Repo.Complaint.Reklama
-  alias RkBackend.Repo.Complaint.Reklama.ReklamaImage
-  alias RkBackend.Repo.Complaint.Topic
-  alias RkBackend.Repo.Complaint.Message
+  alias RkBackend.Repo.Auth.Users
+  alias RkBackend.Repo.Auth.Roles
+  alias RkBackend.Repo.Auth.Schemas.User
+  alias RkBackend.Repo.Complaint.Reklamas
+  alias RkBackend.Repo.Complaint.Topics
+  alias RkBackend.Repo.Complaint.Messages
+  alias RkBackend.Repo.Complaint.Schemas.Reklama
+  alias RkBackend.Repo.Complaint.Schemas.Reklama.ReklamaImage
+  alias RkBackend.Repo.Complaint.Schemas.Topic
+  alias RkBackend.Repo.Complaint.Schemas.Message
 
   describe "reklamas" do
     @valid_args %{
@@ -25,7 +29,7 @@ defmodule RkBackend.Repo.ComplaintTest do
 
     def reklama_fixture(args \\ %{}) do
       user =
-        Repo.get_by(Auth.User, email: "some email")
+        Repo.get_by(User, email: "some email")
         |> case do
           nil ->
             user_fixture()
@@ -51,7 +55,7 @@ defmodule RkBackend.Repo.ComplaintTest do
 
       args
       |> Enum.into(valid_args)
-      |> Complaint.store_reklama()
+      |> Reklamas.store_reklama()
       |> case do
         {:ok, reklama} ->
           reklama
@@ -76,7 +80,7 @@ defmodule RkBackend.Repo.ComplaintTest do
       {:ok, user} =
         args
         |> Enum.into(valid_args)
-        |> Auth.store_user()
+        |> Users.store_user()
 
       user
     end
@@ -85,7 +89,7 @@ defmodule RkBackend.Repo.ComplaintTest do
       {:ok, role} =
         args
         |> Enum.into(%{type: "USER"})
-        |> Auth.store_role()
+        |> Roles.store_role()
 
       role
     end
@@ -131,7 +135,7 @@ defmodule RkBackend.Repo.ComplaintTest do
         per_page: 10
       }
 
-      assert [%Reklama{}] = Complaint.list_reklamas(metadata).reklamas
+      assert [%Reklama{}] = Reklamas.list_reklamas(metadata).reklamas
     end
 
     test "list_reklama/1 returns reklamas paginated and filtered" do
@@ -145,7 +149,7 @@ defmodule RkBackend.Repo.ComplaintTest do
         }
       }
 
-      assert [%Reklama{title: "Some Title"}] = Complaint.list_reklamas(metadata).reklamas
+      assert [%Reklama{title: "Some Title"}] = Reklamas.list_reklamas(metadata).reklamas
     end
 
     test "list_reklama/1 returns reklamas paginated and filtered not found" do
@@ -159,7 +163,7 @@ defmodule RkBackend.Repo.ComplaintTest do
         }
       }
 
-      assert [] = Complaint.list_reklamas(metadata).reklamas
+      assert [] = Reklamas.list_reklamas(metadata).reklamas
     end
 
     test "list_reklama/1 returns reklamas paginated and ordered" do
@@ -174,14 +178,14 @@ defmodule RkBackend.Repo.ComplaintTest do
         }
       }
 
-      assert [%Reklama{title: "A"}] = Complaint.list_reklamas(metadata).reklamas
+      assert [%Reklama{title: "A"}] = Reklamas.list_reklamas(metadata).reklamas
     end
 
     test "update_reklama/1 without associations" do
       reklama = reklama_fixture(@valid_args)
       update = Map.put(@update_args, :id, reklama.id)
 
-      assert {:ok, %Reklama{title: "Updated Title"}} = Complaint.update_reklama(update)
+      assert {:ok, %Reklama{title: "Updated Title"}} = Reklamas.update_reklama(update)
     end
 
     test "update_reklama/1 with associations" do
@@ -219,7 +223,7 @@ defmodule RkBackend.Repo.ComplaintTest do
         |> Map.put(:id, reklama.id)
         |> Map.put(:images, images_update)
 
-      assert {:ok, %Reklama{title: "Updated Title"}} = result = Complaint.update_reklama(update)
+      assert {:ok, %Reklama{title: "Updated Title"}} = result = Reklamas.update_reklama(update)
 
       assert {:ok, %Reklama{images: [%{name: "image_updated_1"}, %{name: "image_updated_2"}]}} =
                result
@@ -249,7 +253,7 @@ defmodule RkBackend.Repo.ComplaintTest do
         |> Map.put(:id, reklama.id)
         |> Map.put(:images, images_update)
 
-      assert {:ok, %Reklama{title: "Updated Title"}} = result = Complaint.update_reklama(update)
+      assert {:ok, %Reklama{title: "Updated Title"}} = result = Reklamas.update_reklama(update)
       assert {:ok, %Reklama{images: []}} = result
       assert [] = Repo.all(ReklamaImage)
     end
@@ -274,7 +278,7 @@ defmodule RkBackend.Repo.ComplaintTest do
     def topic_fixture(args \\ %{}) do
       args
       |> Enum.into(@valid_args)
-      |> Complaint.store_topic()
+      |> Topics.store_topic()
       |> case do
         {:ok, topic} ->
           topic
@@ -300,7 +304,7 @@ defmodule RkBackend.Repo.ComplaintTest do
       topic = topic_fixture(@valid_args)
       update = Map.put(@update_args, :id, topic.id)
 
-      assert {:ok, %Topic{description: "Updated description"}} = Complaint.update_topic(update)
+      assert {:ok, %Topic{description: "Updated description"}} = Topics.update_topic(update)
     end
 
     test "update_topic/1 with new  image" do
@@ -311,7 +315,7 @@ defmodule RkBackend.Repo.ComplaintTest do
         |> Map.put(:image, <<0, 255, 42>>)
         |> Map.put(:image_name, "imageUpdated")
 
-      assert {:ok, %Topic{image_name: "imageUpdated"}} = Complaint.update_topic(update)
+      assert {:ok, %Topic{image_name: "imageUpdated"}} = Topics.update_topic(update)
     end
   end
 
@@ -325,7 +329,7 @@ defmodule RkBackend.Repo.ComplaintTest do
 
     def message_fixture(args \\ %{}) do
       user =
-        Repo.get_by(Auth.User, email: "some email")
+        Repo.get_by(User, email: "some email")
         |> case do
           nil ->
             user_fixture()
@@ -343,7 +347,7 @@ defmodule RkBackend.Repo.ComplaintTest do
 
       args
       |> Enum.into(valid_args)
-      |> Complaint.store_message()
+      |> Messages.store_message()
       |> case do
         {:ok, topic} ->
           topic

--- a/test/rk_backend/utils/utils_test.exs
+++ b/test/rk_backend/utils/utils_test.exs
@@ -2,7 +2,7 @@ defmodule RkBackend.UtilsTest do
   use RkBackend.DataCase
 
   alias RkBackend.Utils
-  alias RkBackend.Repo.Auth.User
+  alias RkBackend.Repo.Auth.Schemas.User
 
   describe "utils" do
     @invalid_args %{


### PR DESCRIPTION
  - Ecto Schemas were moved to its own file.
  - Each Ecto Schema has its own Repo module.
  - Module Logic.Auth have been moved to Auth/
  - Migrations now have a default user and roles.

closes #44