### PR TITLE
UTC_DATETIME And Default Topic

### DIFF
--- a/lib/rk_backend/repo/auth/schemas/role.ex
+++ b/lib/rk_backend/repo/auth/schemas/role.ex
@@ -1,5 +1,7 @@
 defmodule RkBackend.Repo.Auth.Schemas.Role do
   use Ecto.Schema
+  @timestamps_opts [type: :utc_datetime]
+
   import Ecto.Changeset
 
   alias RkBackend.Repo.Auth.Schemas.User

--- a/lib/rk_backend/repo/auth/schemas/user.ex
+++ b/lib/rk_backend/repo/auth/schemas/user.ex
@@ -1,5 +1,7 @@
 defmodule RkBackend.Repo.Auth.Schemas.User do
   use Ecto.Schema
+  @timestamps_opts [type: :utc_datetime]
+
   import Ecto.Changeset
 
   alias RkBackend.Repo.Auth.Schemas.Role

--- a/lib/rk_backend/repo/complaint/reklamas.ex
+++ b/lib/rk_backend/repo/complaint/reklamas.ex
@@ -3,6 +3,7 @@ defmodule RkBackend.Repo.Complaint.Reklamas do
 
   alias RkBackend.Repo
   alias RkBackend.Repo.Complaint.Schemas.Reklama
+  alias RkBackend.Repo.Complaint.Schemas.Topic
 
   @moduledoc """
   Provide functions to manage Reklamas.
@@ -21,6 +22,9 @@ defmodule RkBackend.Repo.Complaint.Reklamas do
 
   """
   def store_reklama(args) do
+    general_topic = Repo.get_by!(Topic, title: "General")
+    args = Map.put(args, :topic_id, general_topic.id)
+
     %Reklama{}
     |> Reklama.changeset(args)
     |> Repo.insert()

--- a/lib/rk_backend/repo/complaint/schemas/message.ex
+++ b/lib/rk_backend/repo/complaint/schemas/message.ex
@@ -1,5 +1,7 @@
 defmodule RkBackend.Repo.Complaint.Schemas.Message do
   use Ecto.Schema
+  @timestamps_opts [type: :utc_datetime]
+
   import Ecto.Changeset
 
   alias RkBackend.Repo.Auth.Schemas.User

--- a/lib/rk_backend/repo/complaint/schemas/reklama.ex
+++ b/lib/rk_backend/repo/complaint/schemas/reklama.ex
@@ -1,5 +1,7 @@
 defmodule RkBackend.Repo.Complaint.Schemas.Reklama do
   use Ecto.Schema
+  @timestamps_opts [type: :utc_datetime]
+
   import Ecto.Changeset
 
   alias RkBackend.Repo.Auth.Schemas.User

--- a/lib/rk_backend/repo/complaint/schemas/reklama/reklama_image.ex
+++ b/lib/rk_backend/repo/complaint/schemas/reklama/reklama_image.ex
@@ -1,5 +1,7 @@
 defmodule RkBackend.Repo.Complaint.Schemas.Reklama.ReklamaImage do
   use Ecto.Schema
+  @timestamps_opts [type: :utc_datetime]
+
   import Ecto.Changeset
 
   alias RkBackend.Repo.Complaint.Schemas.Reklama

--- a/lib/rk_backend/repo/complaint/schemas/topic.ex
+++ b/lib/rk_backend/repo/complaint/schemas/topic.ex
@@ -1,5 +1,7 @@
 defmodule RkBackend.Repo.Complaint.Schemas.Topic do
   use Ecto.Schema
+  @timestamps_opts [type: :utc_datetime]
+
   import Ecto.Changeset
 
   alias RkBackend.Repo.Complaint.Schemas.Reklama

--- a/lib/rk_backend_web/types/complaint_types.ex
+++ b/lib/rk_backend_web/types/complaint_types.ex
@@ -49,7 +49,6 @@ defmodule RkBackendWeb.Schema.Types.ComplaintTypes do
     field :title, non_null(:string)
     field :content, non_null(:string)
     field :images, list_of(:reklama_image_details)
-    field :topic_id, non_null(:integer)
   end
 
   input_object :update_reklama_details do
@@ -87,7 +86,7 @@ defmodule RkBackendWeb.Schema.Types.ComplaintTypes do
     field :id, non_null(:integer)
     field :title, :string
     field :description, :string
-    field :images, :upload
+    field :image, :upload
   end
 
   input_object :message_details do

--- a/priv/repo/migrations/20190501125321_create_roles.exs
+++ b/priv/repo/migrations/20190501125321_create_roles.exs
@@ -5,7 +5,7 @@ defmodule RkBackend.Repo.Migrations.CreateRoles do
 
   def change do
     create table(:roles) do
-      add :type, :string, null: false
+      add :type, :string, size: 20, null: false
 
       timestamps()
     end

--- a/priv/repo/migrations/20190514211046_create_users.exs
+++ b/priv/repo/migrations/20190514211046_create_users.exs
@@ -6,10 +6,10 @@ defmodule RkBackend.Repo.Migrations.CreateUsers do
 
   def change do
     create table(:users) do
-      add :full_name, :string, null: false
-      add :email, :string, null: false
-      add :password_hash, :string, null: false
-      add :avatar_name, :string
+      add :full_name, :string, size: 100, null: false
+      add :email, :string, size: 50, null: false
+      add :password_hash, :string, size: 250, null: false
+      add :avatar_name, :string, size: 40
       add :avatar, :binary
 
       add :role_id, references(:roles), null: false

--- a/priv/repo/migrations/20200319193644_create_topic.exs
+++ b/priv/repo/migrations/20200319193644_create_topic.exs
@@ -1,16 +1,29 @@
 defmodule RkBackend.Repo.Migrations.CreateTopic do
   use Ecto.Migration
 
+  alias RkBackend.Repo.Complaint.Topics
+
   def change do
     create table(:topics) do
-      add :title, :string, null: false
-      add :description, :string, null: false
-      add :image_name, :string, null: false
+      add :title, :string, size: 50, null: false
+      add :description, :string, size: 100, null: false
+      add :image_name, :string, size: 50, null: false
       add :image, :binary, null: false
 
       timestamps()
     end
 
     create unique_index(:topics, [:title])
+
+    flush()
+
+    # General topic
+    %{
+      title: "General",
+      description: "All complaints are initailize with this topic till they are reorganized",
+      image_name: "general_image",
+      image: <<0, 0, 0>>
+    }
+    |> Topics.store_topic()
   end
 end

--- a/priv/repo/migrations/20200319200349_create_reklamas.exs
+++ b/priv/repo/migrations/20200319200349_create_reklamas.exs
@@ -3,8 +3,8 @@ defmodule RkBackend.Repo.Migrations.CreateReklamas do
 
   def change do
     create table(:reklamas) do
-      add :title, :string, null: false, null: false
-      add :content, :string, null: false, null: false
+      add :title, :string, size: 100, null: false
+      add :content, :string, size: 3_000, null: false
 
       add :user_id, references(:users), null: false
       add :topic_id, references(:topics, on_delete: :delete_all), null: false

--- a/priv/repo/migrations/20200320170959_create_messages.exs
+++ b/priv/repo/migrations/20200320170959_create_messages.exs
@@ -3,7 +3,7 @@ defmodule RkBackend.Repo.Migrations.CreateMessages do
 
   def change do
     create table(:messages) do
-      add :content, :string, null: false
+      add :content, :string, size: 500, null: false
 
       add :user_id, references(:users, on_delete: :delete_all), null: false
       add :reklama_id, references(:reklamas, on_delete: :delete_all), null: false

--- a/priv/repo/migrations/20200321122624_create_reklama_images.exs
+++ b/priv/repo/migrations/20200321122624_create_reklama_images.exs
@@ -3,7 +3,7 @@ defmodule RkBackend.Repo.Migrations.CreateReklamaImages do
 
   def change do
     create table(:reklama_images) do
-      add :name, :string, null: false
+      add :name, :string, size: 50, null: false
       add :image, :binary, null: false
 
       add :reklama_id, references(:reklamas, on_delete: :delete_all), null: false

--- a/test/rk_backend_web/queries/complaint_queries/reklama_queries_test.exs
+++ b/test/rk_backend_web/queries/complaint_queries/reklama_queries_test.exs
@@ -135,19 +135,15 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries.ReklamaQueriesTest do
 
   describe "Mutations" do
     test "create reklama", %{conn: conn} do
-      topic = Fixture.create(:topic)
-
       reklama_details = %{
         title: "Title",
-        content: "Content",
-        topic_id: topic.id
+        content: "Content"
       }
 
       query = """
         mutation { createReklama(reklamaDetails: {
           title: "#{reklama_details.title}",
-          content: "#{reklama_details.content}",
-          topicId: #{reklama_details.topic_id}
+          content: "#{reklama_details.content}"
         }) { id }}
       """
 

--- a/test/rk_backend_web/queries/complaint_queries/topic_queries_test.exs
+++ b/test/rk_backend_web/queries/complaint_queries/topic_queries_test.exs
@@ -49,7 +49,7 @@ defmodule RkBackendWeb.Schema.Queries.ComplaintQueries.TopicQueriesTest do
         |> post("/graphiql", %{"query" => query})
 
       decode_response = json_response(res, 200)["data"]["topics"]
-      assert [%{"id" => _}] = decode_response
+      assert [%{"id" => _} | _] = decode_response
     end
   end
 


### PR DESCRIPTION
    - All Repo Schemas now use UTC_DATETIME
    - All Reklamas have a General Topic now by default when they are created.
    - Fixed bug in Topic's GraphQL object, now it has an image attribute instead of images.
    - All database's Strings specify their sizes.

This closes #60, closes #61, closes #62, closes #63